### PR TITLE
Support GHC 8.10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,13 @@ matrix:
     compiler: ": #GHC 8.6.3"
     addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc]}}
 
-  - env: BUILD=cabal GHCVER=8.8.1 CABALVER=3.0 CABALPREF="v1-"
-    compiler: ": #GHC 8.8.1"
-    addons: {apt: {packages: [cabal-install-3.0,ghc-8.8.1], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.8.4 CABALVER=3.0 CABALPREF="v1-"
+    compiler: ": #GHC 8.8.4"
+    addons: {apt: {packages: [cabal-install-3.0,ghc-8.8.4], sources: [hvr-ghc]}}
+
+  - env: BUILD=cabal GHCVER=8.10.2 CABALVER=3.2 CABALPREF="v1-"
+    compiler: ": #GHC 8.10.2"
+    addons: {apt: {packages: [cabal-install-3.2,ghc-8.10.1], sources: [hvr-ghc]}}
 
   - env: BUILD=cabal GHCVER=head  CABALVER=head CABALPREF="v1-"
     compiler: ": #GHC HEAD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
 
   - env: BUILD=cabal GHCVER=8.10.2 CABALVER=3.2 CABALPREF="v1-"
     compiler: ": #GHC 8.10.2"
-    addons: {apt: {packages: [cabal-install-3.2,ghc-8.10.1], sources: [hvr-ghc]}}
+    addons: {apt: {packages: [cabal-install-3.2,ghc-8.10.2], sources: [hvr-ghc]}}
 
   - env: BUILD=cabal GHCVER=head  CABALVER=head CABALPREF="v1-"
     compiler: ": #GHC HEAD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,18 @@ matrix:
     compiler: ": #stack 8.6.3"
     addons: {apt: {packages: [libgmp-dev]}}
 
+  - env: BUILD=stack ARGS="--resolver lts-14"
+    compiler: ": #stack 8.6.5"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-15"
+    compiler: ": #stack 8.8.2"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-16"
+    compiler: ": #stack 8.8.4"
+    addons: {apt: {packages: [libgmp-dev]}}
+
   - env: BUILD=stack ARGS="--resolver nightly"
     compiler: ": #stack nightly"
     addons: {apt: {packages: [libgmp-dev]}}
@@ -134,6 +146,10 @@ matrix:
 
   - env: BUILD=stack ARGS="--resolver lts-13"
     compiler: ": #stack 8.6.3 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-15"
+    compiler: ": #stack 8.8.2 osx"
     os: osx
 
   - env: BUILD=stack ARGS="--resolver nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,18 @@ matrix:
     compiler: ": #stack 8.6.3 +constraints"
     addons: {apt: {packages: [libgmp-dev]}}
 
+  - env: BUILD=stack ARGS="--resolver lts-14" PFLAGS="--flag *:constraints"
+    compiler: ": #stack 8.6.5 +constraints"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-15" PFLAGS="--flag *:constraints"
+    compiler: ": #stack 8.8.2 +constraints"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-16" PFLAGS="--flag *:constraints"
+    compiler: ": #stack 8.8.4 +constraints"
+    addons: {apt: {packages: [libgmp-dev]}}
+
   - env: BUILD=stack ARGS="--resolver nightly" PFLAGS="--flag *:constraints"
     compiler: ": #stack nightly +constraints"
     addons: {apt: {packages: [libgmp-dev]}}

--- a/Setup.hs
+++ b/Setup.hs
@@ -26,7 +26,9 @@ module Main (main) where
 import Distribution.PackageDescription
 import Distribution.Simple
 import qualified Distribution.ModuleName as ModuleName
-#if MIN_VERSION_Cabal(2,0,0)
+#if MIN_VERSION_Cabal(3,5,0)
+import Distribution.Types.ModuleReexport
+#elif MIN_VERSION_Cabal(2,0,0)
 import Distribution.Types.CondTree (CondBranch(CondBranch))
 #endif
 
@@ -43,7 +45,13 @@ addReexportsCT :: CondTree ConfVar [Dependency] Library
 addReexportsCT ct = ct
     { condTreeComponents = reexportBranch : condTreeComponents ct }
   where
-    constraintsCondition = Var (Flag (mkFlagName "constraints"))
+    constraintsCondition = Var (
+#if MIN_VERSION_Cabal(3,5,0)
+                              PackageFlag
+#else
+                              Flag
+#endif
+                                 (mkFlagName "constraints"))
     reexportContent   = mempty
       { reexportedModules =
          [ ModuleReexport

--- a/src/Data/Constraint/Bare.hs
+++ b/src/Data/Constraint/Bare.hs
@@ -28,7 +28,12 @@ module Data.Constraint.Bare
 
 
 import Data.Constraint (Dict (..))
-import GHC.Base        (Constraint, Type, unsafeCoerce#)
+import GHC.Base        (Constraint, Type)
+#if __GLASGOW_HASKELL__ >= 900
+import GHC.Exts        (unsafeCoerce#)
+#elif
+import GHC.Base        (unsafeCoerce#)
+#endif
 
 -- | An unsafeCoerced pointer to a Constraint, such as a class function dictionary.
 data BareConstraint :: Constraint -> Type

--- a/src/Data/Constraint/Bare.hs
+++ b/src/Data/Constraint/Bare.hs
@@ -31,7 +31,7 @@ import Data.Constraint (Dict (..))
 import GHC.Base        (Constraint, Type)
 #if __GLASGOW_HASKELL__ >= 900
 import GHC.Exts        (unsafeCoerce#)
-#elif
+#else
 import GHC.Base        (unsafeCoerce#)
 #endif
 

--- a/src/Data/Constraint/Deriving/ClassDict.hs
+++ b/src/Data/Constraint/Deriving/ClassDict.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
@@ -209,11 +208,6 @@ mapResultType f t
   | (bndrs@(_:_), t') <- splitForAllTys t
     = mkSpecForAllTys bndrs $ mapResultType f t'
   | Just (at, rt) <- splitFunTy_maybe t
-#if __GLASGOW_HASKELL__ >= 810
-    = mkVisFunTy
-#else
-    = mkFunTy
-#endif
-         at (mapResultType f rt)
+    = mkVisFunTy at (mapResultType f rt)
   | otherwise
     = f t

--- a/src/Data/Constraint/Deriving/ClassDict.hs
+++ b/src/Data/Constraint/Deriving/ClassDict.hs
@@ -10,7 +10,7 @@ module Data.Constraint.Deriving.ClassDict
 import           Control.Monad (join, unless, when)
 import           Data.Data     (Data)
 import           Data.Maybe    (fromMaybe, isJust)
-import           GhcPlugins    hiding (OverlapMode (..), overlapMode)
+import           GhcPlugins    hiding (OverlapMode (..), overlapMode, mkFunTy)
 import qualified Unify
 
 import Data.Constraint.Deriving.CorePluginM
@@ -207,7 +207,7 @@ mapResultType :: (Type -> Type) -> Type -> Type
 mapResultType f t
   | (bndrs@(_:_), t') <- splitForAllTys t
     = mkSpecForAllTys bndrs $ mapResultType f t'
-  | Just (at, rt) <- splitFunTy_maybe t
-    = mkVisFunTy at (mapResultType f rt)
+  | Just (vis, at, rt) <- splitFunTyArg_maybe t
+    = mkFunTy vis at (mapResultType f rt)
   | otherwise
     = f t

--- a/src/Data/Constraint/Deriving/ClassDict.hs
+++ b/src/Data/Constraint/Deriving/ClassDict.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
@@ -208,6 +209,11 @@ mapResultType f t
   | (bndrs@(_:_), t') <- splitForAllTys t
     = mkSpecForAllTys bndrs $ mapResultType f t'
   | Just (at, rt) <- splitFunTy_maybe t
-    = mkFunTy at (mapResultType f rt)
+#if __GLASGOW_HASKELL__ >= 810
+    = mkVisFunTy
+#else
+    = mkFunTy
+#endif
+         at (mapResultType f rt)
   | otherwise
     = f t

--- a/src/Data/Constraint/Deriving/CorePluginM.hs
+++ b/src/Data/Constraint/Deriving/CorePluginM.hs
@@ -588,7 +588,12 @@ replaceTypeOccurrences told tnew = replace
         = mkSpecForAllTys bndrs $ replace t'
         -- split arrow types
       | Just (at, rt) <- splitFunTy_maybe t
-        = mkFunTy (replace at) (replace rt)
+#if __GLASGOW_HASKELL__ >= 810
+        = mkVisFunTy
+#else
+        = mkFunTy
+#endif
+            (replace at) (replace rt)
         -- could not find anything
       | otherwise
         = t

--- a/src/Data/Constraint/Deriving/CorePluginM.hs
+++ b/src/Data/Constraint/Deriving/CorePluginM.hs
@@ -30,6 +30,9 @@ module Data.Constraint.Deriving.CorePluginM
     -- * Debugging
   , pluginDebug, pluginTrace
   , HasCallStack
+#if __GLASGOW_HASKELL__ < 810
+  , mkVisFunTy, mkInvisFunTy, mkVisFunTys, mkInvisFunTys
+#endif
   ) where
 
 import qualified Avail
@@ -588,12 +591,7 @@ replaceTypeOccurrences told tnew = replace
         = mkSpecForAllTys bndrs $ replace t'
         -- split arrow types
       | Just (at, rt) <- splitFunTy_maybe t
-#if __GLASGOW_HASKELL__ >= 810
-        = mkVisFunTy
-#else
-        = mkFunTy
-#endif
-            (replace at) (replace rt)
+        = mkVisFunTy (replace at) (replace rt)
         -- could not find anything
       | otherwise
         = t
@@ -751,4 +749,13 @@ vnDictToBare = mkVarOcc "dictToBare"
 #if __GLASGOW_HASKELL__ < 808
 cnTypeEq :: OccName
 cnTypeEq = mkTcOcc "~"
+#endif
+
+#if __GLASGOW_HASKELL__ < 810
+mkVisFunTy, mkInvisFunTy :: Type -> Type -> Type
+mkVisFunTy = mkFunTy
+mkInvisFunTy = mkFunTy
+mkVisFunTys, mkInvisFunTys :: [Type] -> Type -> Type
+mkVisFunTys = mkFunTys
+mkInvisFunTys = mkFunTys
 #endif

--- a/src/Data/Constraint/Deriving/CorePluginM.hs
+++ b/src/Data/Constraint/Deriving/CorePluginM.hs
@@ -30,6 +30,8 @@ module Data.Constraint.Deriving.CorePluginM
     -- * Debugging
   , pluginDebug, pluginTrace
   , HasCallStack
+  , splitFunTyArg_maybe
+  , mkFunTy
 #if __GLASGOW_HASKELL__ < 810
   , mkVisFunTy, mkInvisFunTy, mkVisFunTys, mkInvisFunTys
 #endif
@@ -48,7 +50,7 @@ import           Data.Semigroup      as Sem (Semigroup (..))
 import qualified ErrUtils
 import qualified Finder
 import           GhcPlugins          hiding (OverlapMode (..), empty,
-                                      overlapMode, (<>))
+                                      overlapMode, (<>), mkFunTy)
 import qualified GhcPlugins
 import qualified IfaceEnv
 import           InstEnv             (InstEnv, InstEnvs)
@@ -59,6 +61,9 @@ import qualified OccName             (varName)
 import           TcRnMonad           (getEps, initTc)
 import           TcRnTypes           (TcM)
 import qualified Unify
+#if __GLASGOW_HASKELL__ >= 810
+import qualified TyCoRep
+#endif
 #if __GLASGOW_HASKELL__ >= 808
 import qualified TysWiredIn
 #endif
@@ -590,8 +595,8 @@ replaceTypeOccurrences told tnew = replace
       | (bndrs@(_:_), t') <- splitForAllTys t
         = mkSpecForAllTys bndrs $ replace t'
         -- split arrow types
-      | Just (at, rt) <- splitFunTy_maybe t
-        = mkVisFunTy (replace at) (replace rt)
+      | Just (vis, at, rt) <- splitFunTyArg_maybe t
+        = mkFunTy vis (replace at) (replace rt)
         -- could not find anything
       | otherwise
         = t
@@ -752,10 +757,32 @@ cnTypeEq = mkTcOcc "~"
 #endif
 
 #if __GLASGOW_HASKELL__ < 810
+type AnonArgFlag = ()
+
 mkVisFunTy, mkInvisFunTy :: Type -> Type -> Type
-mkVisFunTy = mkFunTy
-mkInvisFunTy = mkFunTy
+mkVisFunTy = GhcPlugins.mkFunTy
+mkInvisFunTy = GhcPlugins.mkFunTy
+
 mkVisFunTys, mkInvisFunTys :: [Type] -> Type -> Type
-mkVisFunTys = mkFunTys
-mkInvisFunTys = mkFunTys
+mkVisFunTys = GhcPlugins.mkFunTys
+mkInvisFunTys = GhcPlugins.mkFunTys
+#endif
+
+mkFunTy :: AnonArgFlag -> Type -> Type -> Type
+#if __GLASGOW_HASKELL__ < 810
+mkFunTy _ = GhcPlugins.mkFunTy
+#else
+mkFunTy = TyCoRep.mkFunTy
+#endif
+
+splitFunTyArg_maybe :: Type -> Maybe (AnonArgFlag, Type, Type)
+#if __GLASGOW_HASKELL__ < 810
+splitFunTyArg_maybe ty =
+    case splitFunTy_maybe ty of
+        Just (arg, res) -> Just ((), arg, res)
+        _               -> Nothing
+#else
+splitFunTyArg_maybe ty | Just ty' <- coreView ty = splitFunTyArg_maybe ty'
+splitFunTyArg_maybe (TyCoRep.FunTy vis arg res)  = Just (vis, arg, res)
+splitFunTyArg_maybe _                            = Nothing
 #endif

--- a/src/Data/Constraint/Deriving/DeriveAll.hs
+++ b/src/Data/Constraint/Deriving/DeriveAll.hs
@@ -757,11 +757,8 @@ mtmiToExpression MatchingType {..} mi = do
   let extraTheta
             = filter (\t -> not $ any (eqType t . fst) bndrs) mtTheta
       tRepl = replaceTypeOccurrences mtBaseType mtNewType tOrig
-      tFun  = mkVisFunTys (extraTheta ++ map fst bndrs) tRepl
+      tFun  = mkInvisFunTys (extraTheta ++ map fst bndrs) tRepl
       tvs   =  tyCoVarsOfTypeWellScoped tFun
-#if __GLASGOW_HASKELL__ < 810
-      mkVisFunTys = mkFunTys
-#endif
   return
     ( mkSpecForAllTys tvs tFun
     , mkCoreLams (tvs ++ map mkWildValBinder extraTheta ++ map snd bndrs)

--- a/src/Data/Constraint/Deriving/DeriveAll.hs
+++ b/src/Data/Constraint/Deriving/DeriveAll.hs
@@ -37,6 +37,9 @@ import qualified OccName
 import           Panic               (panicDoc)
 import           TcType              (tcSplitDFunTy)
 import qualified Unify
+#if __GLASGOW_HASKELL__ >= 810
+import           Predicate
+#endif
 
 import Data.Constraint.Deriving.CorePluginM
 
@@ -754,8 +757,11 @@ mtmiToExpression MatchingType {..} mi = do
   let extraTheta
             = filter (\t -> not $ any (eqType t . fst) bndrs) mtTheta
       tRepl = replaceTypeOccurrences mtBaseType mtNewType tOrig
-      tFun  = mkFunTys (extraTheta ++ map fst bndrs) tRepl
-      tvs   = tyCoVarsOfTypeWellScoped tFun
+      tFun  = mkVisFunTys (extraTheta ++ map fst bndrs) tRepl
+      tvs   =  tyCoVarsOfTypeWellScoped tFun
+#if __GLASGOW_HASKELL__ < 810
+      mkVisFunTys = mkFunTys
+#endif
   return
     ( mkSpecForAllTys tvs tFun
     , mkCoreLams (tvs ++ map mkWildValBinder extraTheta ++ map snd bndrs)

--- a/src/Data/Constraint/Deriving/ToInstance.hs
+++ b/src/Data/Constraint/Deriving/ToInstance.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
@@ -152,8 +153,11 @@ toInstance (ToInstance omode) (NonRec bindVar bindExpr) = do
       Nothing -> pluginLocatedError loc notGoodMsg
       Just ma -> pure ma
     let matchedTy = substTyVar match varCls
-        instSig = mkSpecForAllTys bndrs $ mkFunTys theta matchedTy
-        bindBareTy = mkSpecForAllTys bndrs $ mkFunTys theta $ mkTyConApp tcBareConstraint [matchedTy]
+        instSig = mkSpecForAllTys bndrs $ mkVisFunTys theta matchedTy
+        bindBareTy = mkSpecForAllTys bndrs $ mkVisFunTys theta $ mkTyConApp tcBareConstraint [matchedTy]
+#if __GLASGOW_HASKELL__ < 810
+        mkVisFunTys = mkFunTys
+#endif
 
     -- check if constraint is indeed a class and get it
     matchedClass <- case tyConAppTyCon_maybe matchedTy >>= tyConClass_maybe of

--- a/src/Data/Constraint/Deriving/ToInstance.hs
+++ b/src/Data/Constraint/Deriving/ToInstance.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
@@ -153,11 +152,8 @@ toInstance (ToInstance omode) (NonRec bindVar bindExpr) = do
       Nothing -> pluginLocatedError loc notGoodMsg
       Just ma -> pure ma
     let matchedTy = substTyVar match varCls
-        instSig = mkSpecForAllTys bndrs $ mkVisFunTys theta matchedTy
-        bindBareTy = mkSpecForAllTys bndrs $ mkVisFunTys theta $ mkTyConApp tcBareConstraint [matchedTy]
-#if __GLASGOW_HASKELL__ < 810
-        mkVisFunTys = mkFunTys
-#endif
+        instSig = mkSpecForAllTys bndrs $ mkInvisFunTys theta matchedTy
+        bindBareTy = mkSpecForAllTys bndrs $ mkInvisFunTys theta $ mkTyConApp tcBareConstraint [matchedTy]
 
     -- check if constraint is indeed a class and get it
     matchedClass <- case tyConAppTyCon_maybe matchedTy >>= tyConClass_maybe of

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE RecordWildCards   #-}
 module Main (main) where
 
-import           Control.Monad         (when)
+import           Control.Monad         (when, guard)
 import           Data.ByteString       (ByteString)
 import qualified Data.ByteString.Char8 as BS
 import           Data.Char             (isSpace)
@@ -50,7 +50,12 @@ data TargetPaths = TargetPaths
 
 lookupTargetPaths :: Path a File -> Maybe TargetPaths
 lookupTargetPaths p = do
-  if fileExtension p == ".hs" then Just () else Nothing
+#if MIN_VERSION_path(0,7,0)
+  ext <- fileExtension p
+#else
+  let ext = fileExtension p
+#endif
+  guard $ ext == ".hs"
   targetPath <- Just $ toFilePath p
   targetName <- toFilePath <$> setFileExtension "" (filename p)
   stdoutPath <- toFilePath <$> correspondingStdOut p

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -28,7 +28,7 @@ import           System.FilePath       (isPathSeparator)
 import           System.IO
 
 #if !MIN_VERSION_path(0,7,0)
-replaceExtension :: MonadThrow m => String -> Path b File -> m (Path b File)
+replaceExtension :: String -> Path b File -> Maybe (Path b File)
 replaceExtension = setFileExtension
 #endif
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -27,6 +27,11 @@ import           System.Exit
 import           System.FilePath       (isPathSeparator)
 import           System.IO
 
+#if !MIN_VERSION_path(0,7,0)
+replaceExtension :: MonadThrow m => String -> Path b File -> m (Path b File)
+replaceExtension = setFileExtension
+#endif
+
 -- | Folder with test modules to be compiled
 specDir :: Path Rel Dir
 specDir = [reldir|test/Spec/|]
@@ -36,10 +41,10 @@ outDir :: Path Rel Dir
 outDir = [reldir|test/out/|]
 
 correspondingStdOut :: Path a File -> Maybe (Path Rel File)
-correspondingStdOut f = setFileExtension "stdout" $ outDir </> filename f
+correspondingStdOut f = replaceExtension "stdout" $ outDir </> filename f
 
 correspondingStdErr :: Path a File -> Maybe (Path Rel File)
-correspondingStdErr f = setFileExtension "stderr" $ outDir </> filename f
+correspondingStdErr f = replaceExtension "stderr" $ outDir </> filename f
 
 data TargetPaths = TargetPaths
   { targetName :: String
@@ -57,7 +62,7 @@ lookupTargetPaths p = do
 #endif
   guard $ ext == ".hs"
   targetPath <- Just $ toFilePath p
-  targetName <- toFilePath <$> setFileExtension "" (filename p)
+  targetName <- toFilePath <$> replaceExtension "" (filename p)
   stdoutPath <- toFilePath <$> correspondingStdOut p
   stderrPath <- toFilePath <$> correspondingStdErr p
   return TargetPaths {..}


### PR DESCRIPTION
This package didn't build under 8.10 due to several rearrangements, mostly around `mkFunTy`.  I also did some preliminary work on supporting the upcoming GHC 9 (and Cabal 3.5), although I'm not able to build on 9 yet due to `ghc-lib` issues.